### PR TITLE
feat: Strength of Schedule (SoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "prom-pong-1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/source/.gitignore
+++ b/source/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 # Local/dev data
 db.json
 source.zip
+.env

--- a/source/App.tsx
+++ b/source/App.tsx
@@ -168,7 +168,7 @@ function AppContent() {
   }
 
   if (!firebaseUser) {
-    return <LoginScreen onLoginSuccess={() => {}} />;
+    return <LoginScreen onLoginSuccess={() => { }} />;
   }
 
   if (currentUser?.needsSetup) {
@@ -196,6 +196,7 @@ function AppContent() {
               <Leaderboard
                 players={players}
                 matches={matches}
+                history={history}
                 onPlayerClick={handleLeaderboardPlayerClick}
                 activeLeagueId={activeLeagueId}
                 leagues={leagues}
@@ -453,11 +454,10 @@ function AppContent() {
         {toasts.map((toast) => (
           <div
             key={toast.id}
-            className={`flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg border animate-slideUp ${
-              toast.type === 'success'
+            className={`flex items-center gap-3 px-4 py-3 rounded-lg shadow-lg border animate-slideUp ${toast.type === 'success'
                 ? 'bg-green-900/90 border-green-500/50 text-green-100'
                 : 'bg-red-900/90 border-red-500/50 text-red-100'
-            }`}
+              }`}
           >
             {toast.type === 'success' ? <CheckCircle size={16} /> : <AlertCircle size={16} />}
             <span className="text-sm font-medium flex-1">{toast.message}</span>

--- a/source/components/Leaderboard.tsx
+++ b/source/components/Leaderboard.tsx
@@ -1,20 +1,22 @@
 import React, { useState, useMemo } from 'react';
-import { Player, Match, GameType, League } from '../types';
+import { Player, Match, GameType, League, EloHistoryEntry } from '../types';
 import RankBadge from './RankBadge';
-import { TrendingUp, TrendingDown, Minus, Info, ChevronDown, ChevronUp } from 'lucide-react';
+import { TrendingUp, TrendingDown, Minus, Info, ChevronDown, ChevronUp, Target } from 'lucide-react';
 import { RANKS } from '../constants';
 import { getPlayerStats } from '../utils/gameTypeStats';
 import { partitionPlayers, sortRankedPlayers, sortUnrankedPlayers } from '../utils/playerRanking';
+import { computeSoS, computeAverageElo } from '../utils/sosUtils';
 
 interface LeaderboardProps {
   players: Player[];
   matches: Match[];
+  history?: EloHistoryEntry[];
   onPlayerClick?: (playerId: string) => void;
   activeLeagueId?: string | null;
   leagues?: League[];
 }
 
-const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, onPlayerClick, activeLeagueId, leagues = [] }) => {
+const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, history = [], onPlayerClick, activeLeagueId, leagues = [] }) => {
   const [type, setType] = useState<GameType>('singles');
   const [showInfo, setShowInfo] = useState(false);
 
@@ -37,14 +39,28 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, onPlayerCli
     };
   }, [filteredPlayers, type]);
 
+  // Compute Strength of Schedule using historical Elo and league scoping
+  const sosMap = useMemo(() => {
+    const raw = computeSoS(players, filteredPlayers, matches, history, type, activeLeagueId);
+    const map = new Map<string, number | null>();
+    for (const [id, result] of raw) {
+      map.set(id, result.sos);
+    }
+    return map;
+  }, [players, filteredPlayers, matches, history, type, activeLeagueId]);
+
+  // League average Elo for SoS color coding
+  const leagueAvgElo = useMemo(
+    () => computeAverageElo(filteredPlayers, type),
+    [filteredPlayers, type]
+  );
+
   // Find last ELO delta for each player from the most recent match they were in (memoized)
   const getLastDelta = useMemo(() => {
-    // Pre-filter and sort matches by game type once
     const sortedMatchesByType = [...matches]
       .filter(m => m.type === type)
       .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
 
-    // Return a function that looks up the delta for a specific player
     return (playerId: string): number | null => {
       const lastMatch = sortedMatchesByType.find(
         m => m.winners.includes(playerId) || m.losers.includes(playerId)
@@ -147,6 +163,22 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, onPlayerCli
             <p className="text-xs text-gray-300">In doubles, the <span className="text-white font-bold">average ELO</span> of each team is used for the calculation. Both teammates gain/lose the same amount. Doubles has a separate rating from singles.</p>
           </div>
 
+          {/* Strength of Schedule */}
+          <div className="bg-black/30 rounded-lg p-3 border border-white/5">
+            <h4 className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-2 flex items-center gap-1.5">
+              <Target size={12} className="text-cyber-yellow" /> Strength of Schedule (SoS)
+            </h4>
+            <p className="text-xs text-gray-300 leading-relaxed">
+              SoS shows the <span className="text-white font-bold">average ELO of your opponents</span>. A high SoS means you've been
+              playing strong opponents — your rating is battle-tested. A low SoS means your rating may be inflated from easier matchups.
+            </p>
+            <div className="mt-2 flex gap-3 text-[10px] font-mono">
+              <span className="text-green-400">● Above avg = tough schedule</span>
+              <span className="text-yellow-400">● Near avg = balanced</span>
+              <span className="text-orange-400">● Below avg = easy schedule</span>
+            </div>
+          </div>
+
           {/* Rank Tiers */}
           <div>
             <h4 className="text-xs font-bold text-gray-400 uppercase tracking-widest mb-3">Rank Tiers</h4>
@@ -180,6 +212,7 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, onPlayerCli
                 <th className="p-4 text-center w-16">#</th>
                 <th className="p-4">Player</th>
                 <th className="p-4 text-right">Rating</th>
+                <th className="p-4 text-center hidden lg:table-cell" title="Strength of Schedule — avg opponent ELO">SoS</th>
                 <th className="p-4 text-center hidden md:table-cell">W/L</th>
                 <th className="p-4 text-center hidden sm:table-cell">Streak</th>
               </tr>
@@ -226,6 +259,21 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, onPlayerCli
                           {delta > 0 ? '+' : ''}{delta}
                         </span>
                       )}
+                    </td>
+                    <td className="p-4 text-center hidden lg:table-cell">
+                      {(() => {
+                        const sos = sosMap.get(player.id);
+                        if (sos === null || sos === undefined) {
+                          return <span className="text-gray-600 font-mono text-sm">—</span>;
+                        }
+                        const diff = sos - leagueAvgElo;
+                        const color = diff >= 30 ? 'text-green-400' : diff >= -30 ? 'text-yellow-400' : 'text-orange-400';
+                        return (
+                          <span className={`font-mono text-sm font-bold ${color}`} title={`Avg opponent ELO (league avg: ${leagueAvgElo})`}>
+                            {sos}
+                          </span>
+                        );
+                      })()}
                     </td>
                     <td className="p-4 text-center hidden md:table-cell text-sm text-gray-400 font-mono">
                       <span className="text-green-400">{stats.wins}</span> - <span className="text-red-400">{stats.losses}</span>
@@ -299,6 +347,9 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, onPlayerCli
                           <span className="font-mono text-xl font-bold text-gray-500">
                             {elo}
                           </span>
+                        </td>
+                        <td className="p-4 text-center hidden lg:table-cell">
+                          <span className="text-gray-600 font-mono text-sm">—</span>
                         </td>
                         <td className="p-4 text-center hidden md:table-cell text-sm text-gray-500 font-mono">
                           0 - 0

--- a/source/components/Leaderboard.tsx
+++ b/source/components/Leaderboard.tsx
@@ -5,7 +5,7 @@ import { TrendingUp, TrendingDown, Minus, Info, ChevronDown, ChevronUp, Target }
 import { RANKS } from '../constants';
 import { getPlayerStats } from '../utils/gameTypeStats';
 import { partitionPlayers, sortRankedPlayers, sortUnrankedPlayers } from '../utils/playerRanking';
-import { computeSoS, computeAverageElo } from '../utils/sosUtils';
+import { computeSoS } from '../utils/sosUtils';
 
 interface LeaderboardProps {
   players: Player[];
@@ -49,11 +49,6 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, history = [
     return map;
   }, [players, filteredPlayers, matches, history, type, activeLeagueId]);
 
-  // League average Elo for SoS color coding
-  const leagueAvgElo = useMemo(
-    () => computeAverageElo(filteredPlayers, type),
-    [filteredPlayers, type]
-  );
 
   // Find last ELO delta for each player from the most recent match they were in (memoized)
   const getLastDelta = useMemo(() => {
@@ -169,13 +164,13 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, history = [
               <Target size={12} className="text-cyber-yellow" /> Strength of Schedule (SoS)
             </h4>
             <p className="text-xs text-gray-300 leading-relaxed">
-              SoS shows the <span className="text-white font-bold">average ELO of your opponents</span>. A high SoS means you've been
-              playing strong opponents — your rating is battle-tested. A low SoS means your rating may be inflated from easier matchups.
+              SoS shows the <span className="text-white font-bold">average ELO of your opponents</span>. Color is relative to <span className="text-white font-bold">your own rating</span> —
+              green means your opponents are near or above your level, orange means you've been playing well below your level.
             </p>
             <div className="mt-2 flex gap-3 text-[10px] font-mono">
-              <span className="text-green-400">● Above avg = tough schedule</span>
-              <span className="text-yellow-400">● Near avg = balanced</span>
-              <span className="text-orange-400">● Below avg = easy schedule</span>
+              <span className="text-green-400">● Near your ELO or above</span>
+              <span className="text-yellow-400">● Moderately below your ELO</span>
+              <span className="text-orange-400">● Well below your ELO</span>
             </div>
           </div>
 
@@ -266,10 +261,10 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, history = [
                         if (sos === null || sos === undefined) {
                           return <span className="text-gray-600 font-mono text-sm">—</span>;
                         }
-                        const diff = sos - leagueAvgElo;
-                        const color = diff >= 30 ? 'text-green-400' : diff >= -30 ? 'text-yellow-400' : 'text-orange-400';
+                        const gap = sos - elo;
+                        const color = gap >= -30 ? 'text-green-400' : gap >= -100 ? 'text-yellow-400' : 'text-orange-400';
                         return (
-                          <span className={`font-mono text-sm font-bold ${color}`} title={`Avg opponent ELO (league avg: ${leagueAvgElo})`}>
+                          <span className={`font-mono text-sm font-bold ${color}`} title={`Avg opponent ELO (your ELO: ${elo})`}>
                             {sos}
                           </span>
                         );

--- a/source/components/Leaderboard.tsx
+++ b/source/components/Leaderboard.tsx
@@ -5,7 +5,7 @@ import { TrendingUp, TrendingDown, Minus, Info, ChevronDown, ChevronUp, Target }
 import { RANKS } from '../constants';
 import { getPlayerStats } from '../utils/gameTypeStats';
 import { partitionPlayers, sortRankedPlayers, sortUnrankedPlayers } from '../utils/playerRanking';
-import { computeSoS } from '../utils/sosUtils';
+import { computeSoS, getSoSColor } from '../utils/sosUtils';
 
 interface LeaderboardProps {
   players: Player[];
@@ -261,10 +261,8 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ players, matches, history = [
                         if (sos === null || sos === undefined) {
                           return <span className="text-gray-600 font-mono text-sm">—</span>;
                         }
-                        const gap = sos - elo;
-                        const color = gap >= -30 ? 'text-green-400' : gap >= -100 ? 'text-yellow-400' : 'text-orange-400';
                         return (
-                          <span className={`font-mono text-sm font-bold ${color}`} title={`Avg opponent ELO (your ELO: ${elo})`}>
+                          <span className={`font-mono text-sm font-bold ${getSoSColor(sos, elo)}`} title={`Avg opponent ELO (your ELO: ${elo})`}>
                             {sos}
                           </span>
                         );

--- a/source/components/PlayerProfile.tsx
+++ b/source/components/PlayerProfile.tsx
@@ -13,7 +13,7 @@ import {
   getEloVolatility,
   getRecentForm,
 } from '../utils/statsUtils';
-import { computeSoS, computeSoSProgression } from '../utils/sosUtils';
+import { computeSoS, computeSoSProgression, getSoSColor, SOS_THRESHOLD_TOUGH, SOS_THRESHOLD_EASY } from '../utils/sosUtils';
 
 interface PlayerProfileProps {
   player: Player;
@@ -26,11 +26,13 @@ interface PlayerProfileProps {
   currentUserId?: string;
   onNavigateToArmory?: () => void;
   onUpdatePlayerName?: (playerId: string, newName: string) => void;
+  activeLeagueId?: string | null;
 }
 
 const PlayerProfile: React.FC<PlayerProfileProps> = ({
   player, history, matches, rackets, players, onUpdateRacket,
   isAdmin, currentUserId, onNavigateToArmory, onUpdatePlayerName,
+  activeLeagueId,
 }) => {
   const [selectedGameType, setSelectedGameType] = useState<GameType>('singles');
   const [editingName, setEditingName] = useState(false);
@@ -104,15 +106,37 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
 
   // Strength of Schedule: current value and progression
   const currentSoS = useMemo(() => {
-    const result = computeSoS(players, [player], matches, history, selectedGameType);
+    const result = computeSoS(players, [player], matches, history, selectedGameType, activeLeagueId);
     return result.get(player.id)?.sos ?? null;
-  }, [players, player, matches, history, selectedGameType]);
+  }, [players, player, matches, history, selectedGameType, activeLeagueId]);
 
 
   const sosProgression = useMemo(
-    () => computeSoSProgression(player.id, players, matches, history, selectedGameType),
-    [player.id, players, matches, history, selectedGameType]
+    () => computeSoSProgression(player.id, players, matches, history, selectedGameType, activeLeagueId),
+    [player.id, players, matches, history, selectedGameType, activeLeagueId]
   );
+
+  const sosGradientStops = useMemo(() => {
+    const n = sosProgression.length;
+    if (n < 2) return [];
+    const colorOf = (p: { sos: number; playerElo: number }) => {
+      const gap = p.sos - p.playerElo;
+      if (gap >= SOS_THRESHOLD_TOUGH) return '#4ade80';
+      if (gap >= SOS_THRESHOLD_EASY) return '#facc15';
+      return '#fb923c';
+    };
+    const stops: { offset: string; color: string }[] = [];
+    for (let i = 0; i < n; i++) {
+      const color = colorOf(sosProgression[i]);
+      const pct = `${((i / (n - 1)) * 100).toFixed(1)}%`;
+      if (i > 0) {
+        const prevColor = colorOf(sosProgression[i - 1]);
+        if (prevColor !== color) stops.push({ offset: pct, color: prevColor });
+      }
+      stops.push({ offset: pct, color });
+    }
+    return stops;
+  }, [sosProgression]);
 
   const playerMatchCount = filteredMatches.length;
 
@@ -346,12 +370,7 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
          <StatCard
            label="SoS"
            value={currentSoS !== null ? currentSoS : '—'}
-           color={(() => {
-             if (currentSoS === null) return 'text-gray-500';
-             const playerElo = selectedGameType === 'singles' ? player.eloSingles : player.eloDoubles;
-             const gap = currentSoS - playerElo;
-             return gap >= -30 ? 'text-green-400' : gap >= -100 ? 'text-yellow-400' : 'text-orange-400';
-           })()}
+           color={getSoSColor(currentSoS, selectedGameType === 'singles' ? player.eloSingles : player.eloDoubles)}
            icon={<Shield size={16} />}
            tooltip={currentSoS !== null ? `Avg opponent ELO (your ELO: ${selectedGameType === 'singles' ? player.eloSingles : player.eloDoubles})` : 'No qualifying matches'}
          />
@@ -634,6 +653,13 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
               </div>
               <ResponsiveContainer width="100%" height={200}>
                 <LineChart data={sosProgression} margin={{ left: 10, right: 10, top: 5, bottom: 5 }}>
+                  <defs>
+                    <linearGradient id={`sosGrad-${player.id}`} x1="0" y1="0" x2="1" y2="0">
+                      {sosGradientStops.map((stop, i) => (
+                        <stop key={i} offset={stop.offset} stopColor={stop.color} />
+                      ))}
+                    </linearGradient>
+                  </defs>
                   <CartesianGrid strokeDasharray="3 3" stroke="#222" vertical={false} />
                   <XAxis
                     dataKey="matchIndex"
@@ -650,15 +676,28 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
                   <Tooltip
                     contentStyle={{ backgroundColor: '#111', border: '1px solid #333', borderRadius: 8, fontSize: 12 }}
                     labelFormatter={v => `Match #${v}`}
-                    formatter={(value: number) => [value, 'Avg Opp. ELO']}
+                    formatter={(value: number, _name: string, props: any) => {
+                      const point = props.payload as { sos: number; playerElo: number };
+                      return [value, `SoS (your ELO: ${point.playerElo})`];
+                    }}
                   />
                   <Line
                     type="monotone"
                     dataKey="sos"
-                    stroke="#fcee0a"
-                    strokeWidth={2}
-                    dot={false}
-                    activeDot={{ r: 4, fill: '#fcee0a', stroke: '#000' }}
+                    stroke={`url(#sosGrad-${player.id})`}
+                    strokeWidth={2.5}
+                    dot={(dotProps: any) => {
+                      const point = dotProps.payload as { sos: number; playerElo: number };
+                      const gap = point.sos - point.playerElo;
+                      const fill = gap >= SOS_THRESHOLD_TOUGH ? '#4ade80' : gap >= SOS_THRESHOLD_EASY ? '#facc15' : '#fb923c';
+                      return <circle key={dotProps.key} cx={dotProps.cx} cy={dotProps.cy} r={3.5} fill={fill} stroke="#000" strokeWidth={1} />;
+                    }}
+                    activeDot={(dotProps: any) => {
+                      const point = dotProps.payload as { sos: number; playerElo: number };
+                      const gap = point.sos - point.playerElo;
+                      const fill = gap >= SOS_THRESHOLD_TOUGH ? '#4ade80' : gap >= SOS_THRESHOLD_EASY ? '#facc15' : '#fb923c';
+                      return <circle key={dotProps.key} cx={dotProps.cx} cy={dotProps.cy} r={6} fill={fill} stroke="#fff" strokeWidth={2} />;
+                    }}
                   />
                 </LineChart>
               </ResponsiveContainer>

--- a/source/components/PlayerProfile.tsx
+++ b/source/components/PlayerProfile.tsx
@@ -13,7 +13,7 @@ import {
   getEloVolatility,
   getRecentForm,
 } from '../utils/statsUtils';
-import { computeSoS, computeAverageElo, computeSoSProgression } from '../utils/sosUtils';
+import { computeSoS, computeSoSProgression } from '../utils/sosUtils';
 
 interface PlayerProfileProps {
   player: Player;
@@ -108,10 +108,6 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
     return result.get(player.id)?.sos ?? null;
   }, [players, player, matches, history, selectedGameType]);
 
-  const leagueAvgElo = useMemo(
-    () => computeAverageElo(players, selectedGameType),
-    [players, selectedGameType]
-  );
 
   const sosProgression = useMemo(
     () => computeSoSProgression(player.id, players, matches, history, selectedGameType),
@@ -352,11 +348,12 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
            value={currentSoS !== null ? currentSoS : '—'}
            color={(() => {
              if (currentSoS === null) return 'text-gray-500';
-             const diff = currentSoS - leagueAvgElo;
-             return diff >= 30 ? 'text-green-400' : diff >= -30 ? 'text-yellow-400' : 'text-orange-400';
+             const playerElo = selectedGameType === 'singles' ? player.eloSingles : player.eloDoubles;
+             const gap = currentSoS - playerElo;
+             return gap >= -30 ? 'text-green-400' : gap >= -100 ? 'text-yellow-400' : 'text-orange-400';
            })()}
            icon={<Shield size={16} />}
-           tooltip={currentSoS !== null ? `Avg opponent ELO (league avg: ${leagueAvgElo})` : 'No qualifying matches'}
+           tooltip={currentSoS !== null ? `Avg opponent ELO (your ELO: ${selectedGameType === 'singles' ? player.eloSingles : player.eloDoubles})` : 'No qualifying matches'}
          />
       </div>
 
@@ -666,9 +663,9 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
                 </LineChart>
               </ResponsiveContainer>
               <div className="mt-2 flex items-center justify-center gap-4 text-[10px] font-mono">
-                <span className="text-green-400">● &ge; {leagueAvgElo + 30} tough</span>
-                <span className="text-yellow-400">● ~{leagueAvgElo} balanced</span>
-                <span className="text-orange-400">● &le; {leagueAvgElo - 30} easy</span>
+                <span className="text-green-400">● Near/above your ELO</span>
+                <span className="text-yellow-400">● Moderately below</span>
+                <span className="text-orange-400">● Well below your ELO</span>
               </div>
             </div>
           )}

--- a/source/components/PlayerProfile.tsx
+++ b/source/components/PlayerProfile.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useMemo } from 'react';
 import { Player, EloHistoryEntry, Racket, Match, GameType } from '../types';
 import { LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Cell } from 'recharts';
 import { RACKET_ICONS, formatRacketStats } from './RacketManager';
-import { Zap, TrendingUp, TrendingDown, Calendar, Sword, AlertTriangle, Pencil, Check, X, Activity, BarChart3, Target } from 'lucide-react';
+import { Zap, TrendingUp, TrendingDown, Calendar, Sword, AlertTriangle, Pencil, Check, X, Activity, BarChart3, Target, Shield } from 'lucide-react';
 import { getPlayerAchievements } from '../achievements';
 import { getStatsForGameType } from '../utils/gameTypeStats';
 import {
@@ -13,6 +13,7 @@ import {
   getEloVolatility,
   getRecentForm,
 } from '../utils/statsUtils';
+import { computeSoS, computeAverageElo, computeSoSProgression } from '../utils/sosUtils';
 
 interface PlayerProfileProps {
   player: Player;
@@ -99,6 +100,22 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
   const recentForm = useMemo(() =>
     getRecentForm(filteredMatches, player.id, 10),
     [filteredMatches, player.id]
+  );
+
+  // Strength of Schedule: current value and progression
+  const currentSoS = useMemo(() => {
+    const result = computeSoS(players, [player], matches, history, selectedGameType);
+    return result.get(player.id)?.sos ?? null;
+  }, [players, player, matches, history, selectedGameType]);
+
+  const leagueAvgElo = useMemo(
+    () => computeAverageElo(players, selectedGameType),
+    [players, selectedGameType]
+  );
+
+  const sosProgression = useMemo(
+    () => computeSoSProgression(player.id, players, matches, history, selectedGameType),
+    [player.id, players, matches, history, selectedGameType]
   );
 
   const playerMatchCount = filteredMatches.length;
@@ -325,11 +342,22 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
       </div>
 
       {/* Stats Grid */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
          <StatCard label="Matches" value={totalGames} color="text-white" icon={<Calendar size={16} />} />
          <StatCard label="Win Rate" value={`${winRate}%`} color="text-cyber-yellow" />
          <StatCard label="Record" value={`${wins}W - ${losses}L`} color="text-cyber-cyan" />
          <StatCard label={`${selectedGameType === 'singles' ? 'Singles' : 'Doubles'} Streak`} value={Math.abs(streak)} color={streak >= 0 ? 'text-green-400' : 'text-red-400'} icon={streak >= 0 ? <TrendingUp size={16} /> : <TrendingDown size={16} />} />
+         <StatCard
+           label="SoS"
+           value={currentSoS !== null ? currentSoS : '—'}
+           color={(() => {
+             if (currentSoS === null) return 'text-gray-500';
+             const diff = currentSoS - leagueAvgElo;
+             return diff >= 30 ? 'text-green-400' : diff >= -30 ? 'text-yellow-400' : 'text-orange-400';
+           })()}
+           icon={<Shield size={16} />}
+           tooltip={currentSoS !== null ? `Avg opponent ELO (league avg: ${leagueAvgElo})` : 'No qualifying matches'}
+         />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -597,6 +625,54 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
             </div>
           </div>
 
+          {/* SoS Progression */}
+          {sosProgression.length >= 2 && (
+            <div className="glass-panel rounded-xl border border-white/5 p-4">
+              <div className="flex items-center gap-2 mb-4">
+                <Shield size={16} className="text-cyber-yellow" />
+                <h3 className="font-display text-sm text-white tracking-wider">STRENGTH OF SCHEDULE</h3>
+                <span className="text-[10px] font-mono text-gray-500 ml-auto">
+                  Running avg opponent ELO
+                </span>
+              </div>
+              <ResponsiveContainer width="100%" height={200}>
+                <LineChart data={sosProgression} margin={{ left: 10, right: 10, top: 5, bottom: 5 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#222" vertical={false} />
+                  <XAxis
+                    dataKey="matchIndex"
+                    stroke="#555"
+                    fontSize={10}
+                    label={{ value: 'Match #', position: 'insideBottom', offset: -2, fill: '#666', fontSize: 10 }}
+                  />
+                  <YAxis
+                    stroke="#444"
+                    domain={['auto', 'auto']}
+                    tick={{ fill: '#666', fontSize: 10 }}
+                    width={40}
+                  />
+                  <Tooltip
+                    contentStyle={{ backgroundColor: '#111', border: '1px solid #333', borderRadius: 8, fontSize: 12 }}
+                    labelFormatter={v => `Match #${v}`}
+                    formatter={(value: number) => [value, 'Avg Opp. ELO']}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="sos"
+                    stroke="#fcee0a"
+                    strokeWidth={2}
+                    dot={false}
+                    activeDot={{ r: 4, fill: '#fcee0a', stroke: '#000' }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+              <div className="mt-2 flex items-center justify-center gap-4 text-[10px] font-mono">
+                <span className="text-green-400">● &ge; {leagueAvgElo + 30} tough</span>
+                <span className="text-yellow-400">● ~{leagueAvgElo} balanced</span>
+                <span className="text-orange-400">● &le; {leagueAvgElo - 30} easy</span>
+              </div>
+            </div>
+          )}
+
           {/* ELO Volatility Gauge */}
           <div className="glass-panel rounded-xl border border-white/5 p-4">
             <div className="flex items-center gap-2 mb-4">
@@ -644,8 +720,8 @@ const PlayerProfile: React.FC<PlayerProfileProps> = ({
   );
 };
 
-const StatCard = ({ label, value, color, icon }: any) => (
-  <div className="glass-panel p-4 rounded-lg flex flex-col items-center justify-center gap-1 hover:bg-white/5 transition-colors">
+const StatCard = ({ label, value, color, icon, tooltip }: any) => (
+  <div className="glass-panel p-4 rounded-lg flex flex-col items-center justify-center gap-1 hover:bg-white/5 transition-colors" title={tooltip}>
     <div className="text-[10px] text-gray-500 uppercase font-bold flex items-center gap-1">
         {icon} {label}
     </div>

--- a/source/components/PlayersHub.tsx
+++ b/source/components/PlayersHub.tsx
@@ -392,6 +392,7 @@ const PlayersHub: React.FC<PlayersHubProps> = ({
           currentUserId={currentUserId}
           onNavigateToArmory={onNavigateToArmory}
           onUpdatePlayerName={onUpdatePlayerName}
+          activeLeagueId={activeLeagueId}
         />
       )}
 

--- a/source/package.json
+++ b/source/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently \"vite\" \"npx tsx server/index.js\"",
+    "dev": "concurrently \"vite\" \"node --env-file=.env --import tsx server/index.js\"",
     "build": "vite build",
     "preview": "vite preview",
     "start": "node server/index.js",

--- a/source/utils/sosUtils.test.ts
+++ b/source/utils/sosUtils.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for sosUtils — run with: npx tsx utils/sosUtils.test.ts
+ */
+import { computeSoS, computeAverageElo, computeSoSProgression, SoSResult } from './sosUtils';
+import { Player, Match, EloHistoryEntry, GameType } from '../types';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+function makePlayer(id: string, eloSingles: number, eloDoubles = 1200, leagueId?: string): Player {
+    return {
+        id, name: id, avatar: '', eloSingles, eloDoubles,
+        winsSingles: 0, lossesSingles: 0, streakSingles: 0,
+        winsDoubles: 0, lossesDoubles: 0, streakDoubles: 0,
+        joinedAt: '2025-01-01T00:00:00Z', leagueId,
+    };
+}
+
+function makeMatch(
+    id: string, type: GameType, winners: string[], losers: string[],
+    eloChange: number, opts: { isFriendly?: boolean; leagueId?: string } = {}
+): Match {
+    return {
+        id, type, winners, losers,
+        scoreWinner: 21, scoreLoser: 18,
+        timestamp: '2025-06-01T00:00:00Z',
+        eloChange,
+        isFriendly: opts.isFriendly,
+        leagueId: opts.leagueId,
+    };
+}
+
+function makeHistory(playerId: string, matchId: string, newElo: number, gameType: GameType): EloHistoryEntry {
+    return { playerId, matchId, newElo, timestamp: '2025-06-01T00:00:00Z', gameType };
+}
+
+// ── Test runner ──────────────────────────────────────────────────────
+let passed = 0;
+let failed = 0;
+
+function assert(condition: boolean, label: string) {
+    if (condition) {
+        passed++;
+        console.log(`  ✅ ${label}`);
+    } else {
+        failed++;
+        console.error(`  ❌ ${label}`);
+    }
+}
+
+function assertEq(actual: any, expected: any, label: string) {
+    const ok = actual === expected;
+    if (!ok) {
+        console.error(`  ❌ ${label}: expected ${expected}, got ${actual}`);
+        failed++;
+    } else {
+        passed++;
+        console.log(`  ✅ ${label}`);
+    }
+}
+
+// ── Test 1: Historical Elo is used when available ────────────────────
+console.log('\nTest 1: Uses historical Elo over current Elo');
+{
+    const alice = makePlayer('alice', 1400);    // current Elo = 1400
+    const bob = makePlayer('bob', 1500);        // current Elo = 1500 (was 1100 when match happened)
+
+    const match = makeMatch('m1', 'singles', ['alice'], ['bob'], 10);
+
+    // History says Bob was at 1100 after this match (he lost, so pre-match was ~1110)
+    const history = [
+        makeHistory('bob', 'm1', 1100, 'singles'),
+        makeHistory('alice', 'm1', 1410, 'singles'),
+    ];
+
+    const result = computeSoS([alice, bob], [alice], [match], history, 'singles');
+    const aliceSoS = result.get('alice');
+
+    assertEq(aliceSoS?.sos, 1100, 'Alice SoS should use Bob\'s historical Elo (1100), not current (1500)');
+    assertEq(aliceSoS?.matchCount, 1, 'Alice matchCount should be 1');
+}
+
+// ── Test 2: Falls back to current Elo when no history ────────────────
+console.log('\nTest 2: Falls back to current Elo when no history exists');
+{
+    const alice = makePlayer('alice', 1400);
+    const bob = makePlayer('bob', 1300);
+
+    const match = makeMatch('m1', 'singles', ['alice'], ['bob'], 10);
+
+    const result = computeSoS([alice, bob], [alice], [match], [], 'singles');
+    const aliceSoS = result.get('alice');
+
+    assertEq(aliceSoS?.sos, 1300, 'Alice SoS should fall back to Bob\'s current Elo (1300)');
+}
+
+// ── Test 3: Friendly matches are excluded ────────────────────────────
+console.log('\nTest 3: Friendly matches are excluded from SoS');
+{
+    const alice = makePlayer('alice', 1400);
+    const bob = makePlayer('bob', 1100);
+
+    const friendlyMatch = makeMatch('m1', 'singles', ['alice'], ['bob'], 0, { isFriendly: true });
+    const rankedMatch = makeMatch('m2', 'singles', ['alice'], ['bob'], 10);
+
+    const history = [
+        makeHistory('bob', 'm2', 1090, 'singles'),
+        makeHistory('alice', 'm2', 1410, 'singles'),
+    ];
+
+    const result = computeSoS([alice, bob], [alice], [friendlyMatch, rankedMatch], history, 'singles');
+    const aliceSoS = result.get('alice');
+
+    assertEq(aliceSoS?.matchCount, 1, 'Only ranked match should count');
+    assertEq(aliceSoS?.sos, 1090, 'SoS should only include ranked match opponent Elo');
+}
+
+// ── Test 4: League scoping ───────────────────────────────────────────
+console.log('\nTest 4: League scoping filters matches by leagueId');
+{
+    const alice = makePlayer('alice', 1400, 1200, 'league-a');
+    const bob = makePlayer('bob', 1200, 1200, 'league-a');
+    const carol = makePlayer('carol', 1600, 1200, 'league-b');
+
+    // Match 1: Alice vs Bob in league-a
+    const m1 = makeMatch('m1', 'singles', ['alice'], ['bob'], 10, { leagueId: 'league-a' });
+    // Match 2: Alice vs Carol with no league (global)
+    const m2 = makeMatch('m2', 'singles', ['alice'], ['carol'], 5);
+
+    const history = [
+        makeHistory('bob', 'm1', 1190, 'singles'),
+        makeHistory('alice', 'm1', 1410, 'singles'),
+        makeHistory('carol', 'm2', 1595, 'singles'),
+        makeHistory('alice', 'm2', 1415, 'singles'),
+    ];
+
+    // With league-a filter: only m1 counts
+    const resultLeague = computeSoS(
+        [alice, bob, carol], [alice], [m1, m2], history, 'singles', 'league-a'
+    );
+    const sosLeague = resultLeague.get('alice');
+    assertEq(sosLeague?.sos, 1190, 'With league-a filter, SoS uses only Bob\'s Elo from m1');
+    assertEq(sosLeague?.matchCount, 1, 'Only 1 match in league-a');
+
+    // Without league filter: both m1 and m2 count
+    const resultGlobal = computeSoS(
+        [alice, bob, carol], [alice], [m1, m2], history, 'singles', null
+    );
+    const sosGlobal = resultGlobal.get('alice');
+    // Average of Bob's 1190 and Carol's 1595 = round((1190+1595)/2) = 1393
+    assertEq(sosGlobal?.sos, 1393, 'Without filter, SoS averages both opponents');
+    assertEq(sosGlobal?.matchCount, 2, '2 matches globally');
+}
+
+// ── Test 5: Doubles uses eloDoubles ──────────────────────────────────
+console.log('\nTest 5: Doubles mode uses eloDoubles');
+{
+    const alice = makePlayer('alice', 1400, 1300);
+    const bob = makePlayer('bob', 1200, 1100);
+    const carol = makePlayer('carol', 1500, 1450);
+    const dave = makePlayer('dave', 1350, 1250);
+
+    const match = makeMatch('m1', 'doubles', ['alice', 'bob'], ['carol', 'dave'], 10);
+
+    // No history — should fall back to current doublesElo for opponents
+    const result = computeSoS([alice, bob, carol, dave], [alice], [match], [], 'doubles');
+    const aliceSoS = result.get('alice');
+
+    // Alice's opponents are carol (1450) and dave (1250), avg = round((1450+1250)/2) = 1350
+    assertEq(aliceSoS?.sos, 1350, 'Doubles SoS should use eloDoubles of opponents');
+}
+
+// ── Test 6: Player with no matches gets null SoS ─────────────────────
+console.log('\nTest 6: Player with no matches gets null SoS');
+{
+    const alice = makePlayer('alice', 1400);
+    const bob = makePlayer('bob', 1200);
+
+    // No matches at all
+    const result = computeSoS([alice, bob], [alice], [], [], 'singles');
+    const aliceSoS = result.get('alice');
+
+    assertEq(aliceSoS?.sos, null, 'SoS should be null with no matches');
+    assertEq(aliceSoS?.matchCount, 0, 'matchCount should be 0');
+}
+
+// ── Test 7: Opponent not in players array is skipped ─────────────────
+console.log('\nTest 7: Deleted opponent (not in players array) is handled gracefully');
+{
+    const alice = makePlayer('alice', 1400);
+    // bob is NOT in the players array (deleted)
+
+    const match = makeMatch('m1', 'singles', ['alice'], ['bob'], 10);
+
+    // No history for bob either
+    const result = computeSoS([alice], [alice], [match], [], 'singles');
+    const aliceSoS = result.get('alice');
+
+    assertEq(aliceSoS?.sos, null, 'SoS should be null when opponent is deleted and no history');
+    assertEq(aliceSoS?.matchCount, 0, 'matchCount should be 0');
+}
+
+// ── Test 8: Opponent deleted but history exists ──────────────────────
+console.log('\nTest 8: Deleted opponent with history entry still counts');
+{
+    const alice = makePlayer('alice', 1400);
+    // bob is deleted, but history exists for this match
+
+    const match = makeMatch('m1', 'singles', ['alice'], ['bob'], 10);
+    const history = [makeHistory('bob', 'm1', 1150, 'singles')];
+
+    const result = computeSoS([alice], [alice], [match], history, 'singles');
+    const aliceSoS = result.get('alice');
+
+    assertEq(aliceSoS?.sos, 1150, 'SoS should use historical Elo even for deleted opponents');
+    assertEq(aliceSoS?.matchCount, 1, 'matchCount should be 1');
+}
+
+// ── Test 9: computeAverageElo ────────────────────────────────────────
+console.log('\nTest 9: computeAverageElo');
+{
+    const players = [
+        makePlayer('a', 1200), makePlayer('b', 1400), makePlayer('c', 1600),
+    ];
+
+    assertEq(computeAverageElo(players, 'singles'), 1400, 'Average of 1200,1400,1600 = 1400');
+    assertEq(computeAverageElo([], 'singles'), 1200, 'Empty array returns default 1200');
+}
+
+// ── Test 10: Wrong game type history is ignored ──────────────────────
+console.log('\nTest 10: History entries for wrong game type are ignored');
+{
+    const alice = makePlayer('alice', 1400, 1300);
+    const bob = makePlayer('bob', 1200, 1100);
+
+    const match = makeMatch('m1', 'singles', ['alice'], ['bob'], 10);
+
+    // History entry says Bob was at 900 for DOUBLES on this match — should be ignored for singles
+    const history = [makeHistory('bob', 'm1', 900, 'doubles')];
+
+    const result = computeSoS([alice, bob], [alice], [match], history, 'singles');
+    const aliceSoS = result.get('alice');
+
+    // Should fall back to current singles Elo (1200), not the doubles history (900)
+    assertEq(aliceSoS?.sos, 1200, 'Should ignore doubles history for singles SoS');
+}
+
+// ── Test 11: computeSoSProgression basic progression ─────────────────
+console.log('\nTest 11: SoS progression produces correct running average');
+{
+    const alice = makePlayer('alice', 1400);
+    const bob = makePlayer('bob', 1200);
+    const carol = makePlayer('carol', 1600);
+
+    const m1: Match = {
+        ...makeMatch('m1', 'singles', ['alice'], ['bob'], 10),
+        timestamp: '2025-06-01T00:00:00Z',
+    };
+    const m2: Match = {
+        ...makeMatch('m2', 'singles', ['alice'], ['carol'], 5),
+        timestamp: '2025-06-02T00:00:00Z',
+    };
+
+    const history = [
+        makeHistory('bob', 'm1', 1190, 'singles'),
+        makeHistory('carol', 'm2', 1595, 'singles'),
+    ];
+
+    const prog = computeSoSProgression('alice', [alice, bob, carol], [m1, m2], history, 'singles');
+    assertEq(prog.length, 2, 'Should have 2 progression points');
+    assertEq(prog[0].sos, 1190, 'After match 1: SoS = Bob\'s Elo 1190');
+    assertEq(prog[1].sos, 1393, 'After match 2: SoS = avg(1190, 1595) = 1393');
+    assertEq(prog[0].matchIndex, 1, 'First point index is 1');
+    assertEq(prog[1].matchIndex, 2, 'Second point index is 2');
+}
+
+// ── Test 12: computeSoSProgression excludes friendlies ───────────────
+console.log('\nTest 12: SoS progression excludes friendly matches');
+{
+    const alice = makePlayer('alice', 1400);
+    const bob = makePlayer('bob', 1200);
+
+    const friendly: Match = {
+        ...makeMatch('m1', 'singles', ['alice'], ['bob'], 0, { isFriendly: true }),
+        timestamp: '2025-06-01T00:00:00Z',
+    };
+    const ranked: Match = {
+        ...makeMatch('m2', 'singles', ['alice'], ['bob'], 10),
+        timestamp: '2025-06-02T00:00:00Z',
+    };
+
+    const prog = computeSoSProgression('alice', [alice, bob], [friendly, ranked], [], 'singles');
+    assertEq(prog.length, 1, 'Friendly match excluded, only 1 point');
+    assertEq(prog[0].sos, 1200, 'SoS from ranked match uses current Elo fallback');
+}
+
+// ── Test 13: computeSoSProgression empty for player with no matches ──
+console.log('\nTest 13: SoS progression empty for player with no matches');
+{
+    const alice = makePlayer('alice', 1400);
+    const prog = computeSoSProgression('alice', [alice], [], [], 'singles');
+    assertEq(prog.length, 0, 'No matches means empty progression');
+}
+
+// ── Test 14: computeSoSProgression respects league scoping ──────────
+console.log('\nTest 14: SoS progression respects league scoping');
+{
+    const alice = makePlayer('alice', 1400, 1200, 'league-a');
+    const bob = makePlayer('bob', 1200, 1200, 'league-a');
+    const carol = makePlayer('carol', 1600, 1200, 'league-b');
+
+    const m1: Match = {
+        ...makeMatch('m1', 'singles', ['alice'], ['bob'], 10, { leagueId: 'league-a' }),
+        timestamp: '2025-06-01T00:00:00Z',
+    };
+    const m2: Match = {
+        ...makeMatch('m2', 'singles', ['alice'], ['carol'], 5, { leagueId: 'league-b' }),
+        timestamp: '2025-06-02T00:00:00Z',
+    };
+
+    const prog = computeSoSProgression('alice', [alice, bob, carol], [m1, m2], [], 'singles', 'league-a');
+    assertEq(prog.length, 1, 'Only league-a match counts');
+    assertEq(prog[0].sos, 1200, 'SoS from Bob in league-a');
+}
+
+// ── Summary ──────────────────────────────────────────────────────────
+console.log(`\n${'═'.repeat(50)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+    process.exit(1);
+} else {
+    console.log('All tests passed! ✅');
+}

--- a/source/utils/sosUtils.ts
+++ b/source/utils/sosUtils.ts
@@ -1,0 +1,195 @@
+import { Match, Player, GameType, EloHistoryEntry } from '../types';
+
+/**
+ * For a given match, find the opponent(s)' Elo at the time of that match.
+ *
+ * Strategy:
+ *   1. Look for an EloHistoryEntry tied to this match — that gives us the
+ *      opponent's Elo *after* the match. For the opponent-winner, the Elo
+ *      before the match was `newElo - matchDelta`; for the opponent-loser,
+ *      it was `newElo + matchDelta`. However, since we only need an
+ *      approximate SoS, using the post-match Elo is acceptable.
+ *   2. If no history entry is found for the match (e.g. legacy data), fall
+ *      back to the opponent's current Elo.
+ */
+function getOpponentEloAtMatch(
+    oppId: string,
+    match: Match,
+    gameType: GameType,
+    historyByPlayerAndMatch: Map<string, number>,
+    playerMap: Map<string, Player>
+): number | null {
+    // Try historical Elo first (keyed as `playerId:matchId`)
+    const histElo = historyByPlayerAndMatch.get(`${oppId}:${match.id}`);
+    if (histElo !== undefined) return histElo;
+
+    // Fallback: current Elo
+    const opp = playerMap.get(oppId);
+    if (!opp) return null;
+    return gameType === 'singles' ? opp.eloSingles : opp.eloDoubles;
+}
+
+export interface SoSResult {
+    /** Average opponent Elo, or null if no qualifying matches */
+    sos: number | null;
+    /** Number of matches used in the calculation */
+    matchCount: number;
+}
+
+/**
+ * Compute Strength of Schedule for a set of players.
+ *
+ * @param players        All players in the system (for fallback Elo lookup)
+ * @param targetPlayers  The players to compute SoS for (may be a league-filtered subset)
+ * @param matches        All matches
+ * @param history        Elo history entries (for point-in-time Elo)
+ * @param gameType       'singles' or 'doubles'
+ * @param leagueId       If set, only count matches played in this league
+ */
+export function computeSoS(
+    players: Player[],
+    targetPlayers: Player[],
+    matches: Match[],
+    history: EloHistoryEntry[],
+    gameType: GameType,
+    leagueId?: string | null
+): Map<string, SoSResult> {
+    const result = new Map<string, SoSResult>();
+    const playerMap = new Map(players.map(p => [p.id, p]));
+
+    // Build a lookup: "playerId:matchId" -> newElo (post-match)
+    const historyByPlayerAndMatch = new Map<string, number>();
+    for (const h of history) {
+        if (h.gameType === gameType) {
+            historyByPlayerAndMatch.set(`${h.playerId}:${h.matchId}`, h.newElo);
+        }
+    }
+
+    // Filter matches by type, non-friendly, and optionally by league
+    const typeMatches = matches.filter(m => {
+        if (m.type !== gameType) return false;
+        if (m.isFriendly) return false;
+        if (leagueId && m.leagueId !== leagueId) return false;
+        return true;
+    });
+
+    for (const player of targetPlayers) {
+        const opponentElos: number[] = [];
+        let matchCount = 0;
+
+        for (const m of typeMatches) {
+            const isWinner = m.winners.includes(player.id);
+            const isLoser = m.losers.includes(player.id);
+            if (!isWinner && !isLoser) continue;
+
+            const opponents = isWinner ? m.losers : m.winners;
+            let matchCounted = false;
+
+            for (const oppId of opponents) {
+                const elo = getOpponentEloAtMatch(oppId, m, gameType, historyByPlayerAndMatch, playerMap);
+                if (elo !== null) {
+                    opponentElos.push(elo);
+                    matchCounted = true;
+                }
+            }
+
+            if (matchCounted) matchCount++;
+        }
+
+        result.set(player.id, {
+            sos: opponentElos.length > 0
+                ? Math.round(opponentElos.reduce((a, b) => a + b, 0) / opponentElos.length)
+                : null,
+            matchCount,
+        });
+    }
+
+    return result;
+}
+
+/**
+ * Compute the average Elo of a set of players for a given game type.
+ * Returns 1200 (initial Elo) if the set is empty.
+ */
+export function computeAverageElo(
+    players: Player[],
+    gameType: GameType
+): number {
+    if (players.length === 0) return 1200;
+    const sum = players.reduce(
+        (acc, p) => acc + (gameType === 'singles' ? p.eloSingles : p.eloDoubles),
+        0
+    );
+    return Math.round(sum / players.length);
+}
+
+export interface SoSProgressionPoint {
+    matchIndex: number;
+    sos: number;
+    matchId: string;
+    timestamp: string;
+}
+
+/**
+ * Compute SoS progression for a single player — the running average of
+ * opponent Elo after each match, sorted chronologically.
+ *
+ * This gives a timeline of how tough the player's schedule has been over
+ * their career, useful for sparkline/chart displays in player profiles.
+ */
+export function computeSoSProgression(
+    playerId: string,
+    players: Player[],
+    matches: Match[],
+    history: EloHistoryEntry[],
+    gameType: GameType,
+    leagueId?: string | null
+): SoSProgressionPoint[] {
+    const playerMap = new Map(players.map(p => [p.id, p]));
+
+    const historyByPlayerAndMatch = new Map<string, number>();
+    for (const h of history) {
+        if (h.gameType === gameType) {
+            historyByPlayerAndMatch.set(`${h.playerId}:${h.matchId}`, h.newElo);
+        }
+    }
+
+    const playerMatches = matches
+        .filter(m => {
+            if (m.type !== gameType) return false;
+            if (m.isFriendly) return false;
+            if (leagueId && m.leagueId !== leagueId) return false;
+            return m.winners.includes(playerId) || m.losers.includes(playerId);
+        })
+        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
+    const points: SoSProgressionPoint[] = [];
+    let cumulativeSum = 0;
+    let cumulativeCount = 0;
+
+    for (const m of playerMatches) {
+        const isWinner = m.winners.includes(playerId);
+        const opponents = isWinner ? m.losers : m.winners;
+
+        let matchHadElo = false;
+        for (const oppId of opponents) {
+            const elo = getOpponentEloAtMatch(oppId, m, gameType, historyByPlayerAndMatch, playerMap);
+            if (elo !== null) {
+                cumulativeSum += elo;
+                cumulativeCount++;
+                matchHadElo = true;
+            }
+        }
+
+        if (matchHadElo) {
+            points.push({
+                matchIndex: points.length + 1,
+                sos: Math.round(cumulativeSum / cumulativeCount),
+                matchId: m.id,
+                timestamp: m.timestamp,
+            });
+        }
+    }
+
+    return points;
+}

--- a/source/utils/sosUtils.ts
+++ b/source/utils/sosUtils.ts
@@ -1,5 +1,18 @@
 import { Match, Player, GameType, EloHistoryEntry } from '../types';
 
+/** SoS within 30 pts of player's own ELO → tough schedule (green) */
+export const SOS_THRESHOLD_TOUGH = -30;
+/** SoS within 100 pts of player's own ELO → balanced (yellow); below → easy (orange) */
+export const SOS_THRESHOLD_EASY = -100;
+
+export function getSoSColor(sos: number | null, playerElo: number): string {
+    if (sos === null) return 'text-gray-500';
+    const gap = sos - playerElo;
+    if (gap >= SOS_THRESHOLD_TOUGH) return 'text-green-400';
+    if (gap >= SOS_THRESHOLD_EASY) return 'text-yellow-400';
+    return 'text-orange-400';
+}
+
 /**
  * For a given match, find the opponent(s)' Elo at the time of that match.
  *
@@ -126,6 +139,7 @@ export function computeAverageElo(
 export interface SoSProgressionPoint {
     matchIndex: number;
     sos: number;
+    playerElo: number;
     matchId: string;
     timestamp: string;
 }
@@ -182,9 +196,13 @@ export function computeSoSProgression(
         }
 
         if (matchHadElo) {
+            const playerEloAtMatch = historyByPlayerAndMatch.get(`${playerId}:${m.id}`);
+            const fallbackElo = playerMap.get(playerId);
+            const pElo = playerEloAtMatch ?? (fallbackElo ? (gameType === 'singles' ? fallbackElo.eloSingles : fallbackElo.eloDoubles) : 1200);
             points.push({
                 matchIndex: points.length + 1,
                 sos: Math.round(cumulativeSum / cumulativeCount),
+                playerElo: pElo,
                 matchId: m.id,
                 timestamp: m.timestamp,
             });


### PR DESCRIPTION
# ✨ feat: Strength of Schedule (SoS) — Fight Elo Inflation

## 🎯 Problem

Our Elo system has a blind spot: **a 1400-rated player who only beats 1100s looks identical to one who beats other 1400s**. Players can inflate their rating by farming weaker opponents, while those who challenge up get punished with no recognition.

## 💡 Solution

This PR adds a **Strength of Schedule (SoS)** column to the Rankings leaderboard — the **average Elo of all opponents** a player has faced. 

| Player | Elo | SoS | Meaning |
|--------|-----|-----|---------|
| Marco  | 1420 | 🟢 1380 | Battle-tested — played strong opponents |
| Luca   | 1400 | 🟠 1150 | Inflated — farmed easy matchups |

## 🏗 Implementation

### New: [sosUtils.ts](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/utils/sosUtils.ts) — Pure computation engine

```
computeSoS(players, targetPlayers, matches, history, gameType, leagueId?)
  → Map<playerId, { sos: number | null, matchCount: number }>
```

**Key design decisions:**

- **Historical Elo** — Uses [EloHistoryEntry](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/types.ts#62-69) to look up opponent Elo *at match time*, not their current (possibly changed) rating. Falls back to current Elo for legacy matches without history.
- **League scoping** — When viewing a league, only matches within that league count toward SoS. Global view counts everything.
- **Friendly exclusion** — Friendly matches (no Elo impact) are excluded from SoS computation.
- **Deleted opponents** — Gracefully handled via history lookup; if no history exists either, the match is cleanly skipped (no crash).

### Modified: [Leaderboard.tsx](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/components/Leaderboard.tsx)

- New **SoS column** between Rating and W/L (visible on `lg:` screens, hidden on mobile)
- **Color coding** relative to league average Elo:
  - 🟢 Green — SoS ≥ avg + 30 (tough schedule)
  - 🟡 Yellow — SoS within ±30 (balanced)
  - 🟠 Orange — SoS < avg − 30 (easy schedule)
  - Gray dash — no matches
- **Info panel** — New "Strength of Schedule" section in the ℹ️ "How Ranking Works" explainer with color legend
- Accepts new `history` prop for point-in-time Elo lookups

### Modified: [App.tsx](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/App.tsx)

- Passes `history` to `<Leaderboard>` (1 line)

## 📁 Files Changed

| File | Status | Lines |
|------|--------|-------|
| [utils/sosUtils.ts](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/utils/sosUtils.ts) | ✨ New | +124 |
| [utils/sosUtils.test.ts](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/utils/sosUtils.test.ts) | ✨ New | +253 |
| [components/Leaderboard.tsx](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/components/Leaderboard.tsx) | Modified | +53 / −20 |
| [App.tsx](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/App.tsx) | Modified | +1 |
| **Total** | | **+444 / −20** |

## ✅ Testing

**19 unit tests** covering all edge cases — run with `npx tsx utils/sosUtils.test.ts`:

| # | Test | Assertions |
|---|------|------------|
| 1 | Historical Elo used over current Elo | 2 |
| 2 | Falls back to current Elo when no history | 1 |
| 3 | Friendly matches excluded | 2 |
| 4 | League scoping filters correctly | 4 |
| 5 | Doubles mode uses `eloDoubles` | 1 |
| 6 | No matches → null SoS | 2 |
| 7 | Deleted opponent without history → graceful skip | 2 |
| 8 | Deleted opponent with history → still counts | 2 |
| 9 | [computeAverageElo](file:///Users/michele.bellitti/dev/private/prom-pong-1/source/utils/sosUtils.ts#110-125) correctness | 2 |
| 10 | Wrong game type history ignored | 1 |

```
Results: 19 passed, 0 failed ✅
```

## 🔄 Backwards Compatibility

- **Non-breaking** — SoS is purely additive (new column, new info section)
- Existing leaderboard tests should remain unaffected
- Falls back gracefully when `history` prop is not provided (defaults to `[]`)
- No backend changes required — all computation is client-side using existing data

## 📋 Reviewer Checklist

- [ ] SoS column appears on Rankings page (desktop)
- [ ] SoS values change when toggling Singles / Doubles
- [ ] Color coding reflects relative opponent strength
- [ ] Info panel (ℹ️ button) shows SoS explanation
- [ ] Mobile view hides SoS column cleanly
- [ ] League-filtered view scopes SoS to league matches
